### PR TITLE
Fix Prisma JSON typing for subscriptions repositories

### DIFF
--- a/backend/src/modules/subscriptions/infrastructure/repositories/prisma-subscription-plan.repository.ts
+++ b/backend/src/modules/subscriptions/infrastructure/repositories/prisma-subscription-plan.repository.ts
@@ -6,6 +6,19 @@ import {
   SubscriptionPlanRepository,
 } from '../../domain/repositories/subscription-plan.repository';
 
+type SubscriptionPlanRecord = {
+  id: string;
+  name: string;
+  description: string | null;
+  price: number;
+  currency: string;
+  billingPeriod: string;
+  isActive: boolean;
+  metadata: Prisma.JsonValue | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
 @Injectable()
 export class PrismaSubscriptionPlanRepository
   implements SubscriptionPlanRepository
@@ -18,17 +31,19 @@ export class PrismaSubscriptionPlanRepository
       orderBy: { price: 'asc' },
     });
 
-    return records.map((record) => this.toEntity(record));
+    return records.map((record) =>
+      this.toEntity(record as SubscriptionPlanRecord),
+    );
   }
 
   async findById(id: string): Promise<SubscriptionPlanEntity | null> {
     const record = await this.prisma.subscriptionPlan.findUnique({
       where: { id },
     });
-    return record ? this.toEntity(record) : null;
+    return record ? this.toEntity(record as SubscriptionPlanRecord) : null;
   }
 
-  private toEntity(record: Prisma.SubscriptionPlan): SubscriptionPlanEntity {
+  private toEntity(record: SubscriptionPlanRecord): SubscriptionPlanEntity {
     return {
       id: record.id,
       name: record.name,


### PR DESCRIPTION
## Summary
- ensure payment transactions convert metadata and raw responses into Prisma-compatible JSON inputs while preserving entity mapping
- replace direct Prisma.SubscriptionPlan type usage with a local record type to avoid missing type exports

## Testing
- `npm run build` *(fails: nest CLI not found in container because dependencies could not be installed within the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dca37ff3488326aa1ffe57624bd913