### PR TITLE
Refine Prisma repositories to avoid generated client types

### DIFF
--- a/backend/src/modules/auth/infrastructure/repositories/prisma-user.repository.ts
+++ b/backend/src/modules/auth/infrastructure/repositories/prisma-user.repository.ts
@@ -1,8 +1,17 @@
 import { Injectable } from '@nestjs/common';
-import { User as PrismaUser } from '@prisma/client';
 import { PrismaService } from '../../../../database/prisma.service';
 import { User } from '../../domain/entities/user.entity';
 import { UserRepository } from '../../domain/repositories/user.repository';
+
+type PrismaUserRecord = {
+  id: string;
+  name: string;
+  email: string;
+  passwordHash: string;
+  refreshTokenHash: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
 
 @Injectable()
 export class PrismaUserRepository implements UserRepository {
@@ -40,7 +49,7 @@ export class PrismaUserRepository implements UserRepository {
     });
   }
 
-  private toDomain(user: PrismaUser): User {
+  private toDomain(user: PrismaUserRecord): User {
     return User.create({
       id: user.id,
       name: user.name,

--- a/backend/src/modules/business-profile/infrastructure/repositories/prisma-business-permit-profile.repository.ts
+++ b/backend/src/modules/business-profile/infrastructure/repositories/prisma-business-permit-profile.repository.ts
@@ -1,9 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import {
-  BusinessPermitProfile as PrismaBusinessPermitProfile,
-  Prisma,
-  $Enums,
-} from '@prisma/client';
 import { PrismaService } from '../../../../database/prisma.service';
 import {
   BusinessPermitProfile,
@@ -12,7 +7,17 @@ import {
 import { PermitType } from '../../domain/enums/permit-type.enum';
 import { BusinessPermitProfileRepository } from '../../domain/repositories/business-permit-profile.repository';
 
-type PrismaPermitWithRelations = PrismaBusinessPermitProfile;
+type PrismaBusinessPermitProfileRecord = {
+  id: string;
+  businessProfileId: string;
+  permitType: PermitType;
+  formData: JsonValue | null;
+  fieldChecklist: JsonValue | null;
+  documents: JsonValue | null;
+  isChecklistComplete: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
 
 @Injectable()
 export class PrismaBusinessPermitProfileRepository
@@ -54,7 +59,7 @@ export class PrismaBusinessPermitProfileRepository
       create: {
         id: data.id,
         businessProfileId: data.businessProfileId,
-        permitType: data.permitType as $Enums.PermitType,
+        permitType: data.permitType,
         formData: this.toJsonInput(data.formData),
         fieldChecklist: this.toJsonInput(data.fieldChecklist),
         documents: this.toJsonInput(data.documents),
@@ -70,14 +75,16 @@ export class PrismaBusinessPermitProfileRepository
     });
   }
 
-  private toDomain(permit: PrismaPermitWithRelations): BusinessPermitProfile {
+  private toDomain(
+    permit: PrismaBusinessPermitProfileRecord,
+  ): BusinessPermitProfile {
     return BusinessPermitProfile.create({
       id: permit.id,
       businessProfileId: permit.businessProfileId,
-      permitType: permit.permitType as PermitType,
-      formData: permit.formData as JsonValue | null,
-      fieldChecklist: permit.fieldChecklist as JsonValue | null,
-      documents: permit.documents as JsonValue | null,
+      permitType: permit.permitType,
+      formData: permit.formData,
+      fieldChecklist: permit.fieldChecklist,
+      documents: permit.documents,
       isChecklistComplete: permit.isChecklistComplete,
       createdAt: permit.createdAt,
       updatedAt: permit.updatedAt,
@@ -85,14 +92,11 @@ export class PrismaBusinessPermitProfileRepository
   }
 
   private toJsonInput(
-    value: unknown,
-  ): Prisma.InputJsonValue | Prisma.NullableJsonNullValueInput | undefined {
+    value: JsonValue | null | undefined,
+  ): JsonValue | null | undefined {
     if (value === undefined) {
       return undefined;
     }
-    if (value === null) {
-      return Prisma.JsonNull;
-    }
-    return value as Prisma.InputJsonValue;
+    return value ?? null;
   }
 }

--- a/backend/src/modules/documents/infrastructure/mappers/document.mapper.ts
+++ b/backend/src/modules/documents/infrastructure/mappers/document.mapper.ts
@@ -1,15 +1,37 @@
-import {
-  Document as PrismaDocument,
-  DocumentVersion as PrismaDocumentVersion,
-  Prisma,
-} from '@prisma/client';
 import { PermitType } from '../../../business-profile/domain/enums/permit-type.enum';
 import { Document } from '../../domain/entities/document.entity';
 import { DocumentVersion } from '../../domain/entities/document-version.entity';
 
-type DocumentWithRelations = PrismaDocument & {
-  currentVersion?: PrismaDocumentVersion | null;
-  versions?: PrismaDocumentVersion[];
+type DocumentRecord = {
+  id: string;
+  userId: string;
+  businessProfileId: string | null;
+  permitType: PermitType | null;
+  label: string | null;
+  currentVersionId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+};
+
+type DocumentVersionRecord = {
+  id: string;
+  documentId: string;
+  version: number;
+  storageKey: string;
+  originalFilename: string;
+  mimeType: string;
+  size: bigint | number;
+  checksum: string | null;
+  notes: string | null;
+  metadata: unknown;
+  uploadedBy: string | null;
+  createdAt: Date;
+};
+
+type DocumentWithRelations = DocumentRecord & {
+  currentVersion?: DocumentVersionRecord | null;
+  versions?: DocumentVersionRecord[];
 };
 
 export class DocumentMapper {
@@ -30,7 +52,7 @@ export class DocumentMapper {
       id: record.id,
       userId: record.userId,
       businessProfileId: record.businessProfileId,
-      permitType: record.permitType ? (record.permitType as PermitType) : null,
+      permitType: record.permitType,
       label: record.label,
       currentVersion,
       versions,
@@ -40,7 +62,7 @@ export class DocumentMapper {
     });
   }
 
-  static mapVersion(version: PrismaDocumentVersion): DocumentVersion {
+  static mapVersion(version: DocumentVersionRecord): DocumentVersion {
     return DocumentVersion.create({
       id: version.id,
       documentId: version.documentId,
@@ -58,7 +80,7 @@ export class DocumentMapper {
   }
 
   private static parseMetadata(
-    metadata: Prisma.JsonValue | null | undefined,
+    metadata: unknown,
   ): Record<string, unknown> | null {
     if (metadata === null || metadata === undefined) {
       return null;

--- a/backend/src/modules/documents/infrastructure/repositories/prisma-document-version.repository.ts
+++ b/backend/src/modules/documents/infrastructure/repositories/prisma-document-version.repository.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../../../database/prisma.service';
 import { DocumentVersion } from '../../domain/entities/document-version.entity';
 import { DocumentVersionRepository } from '../../domain/repositories/document-version.repository';
@@ -47,9 +46,7 @@ export class PrismaDocumentVersionRepository
         size: BigInt(data.size),
         checksum: data.checksum,
         notes: data.notes,
-        metadata: (data.metadata ?? undefined) as
-          | Prisma.InputJsonValue
-          | undefined,
+        metadata: data.metadata ?? undefined,
         uploadedBy: data.uploadedBy,
         createdAt: data.createdAt,
       },

--- a/backend/src/modules/documents/infrastructure/repositories/prisma-document.repository.ts
+++ b/backend/src/modules/documents/infrastructure/repositories/prisma-document.repository.ts
@@ -1,10 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { Prisma, PermitType } from '@prisma/client';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { PrismaService } from '../../../../database/prisma.service';
 import { Document } from '../../domain/entities/document.entity';
 import { DocumentRepository } from '../../domain/repositories/document.repository';
 import { DocumentMapper } from '../mappers/document.mapper';
+import { PermitType } from '../../../business-profile/domain/enums/permit-type.enum';
 
 @Injectable()
 export class PrismaDocumentRepository implements DocumentRepository {
@@ -62,7 +62,7 @@ export class PrismaDocumentRepository implements DocumentRepository {
           id: data.id,
           userId: data.userId,
           businessProfileId: data.businessProfileId,
-          permitType: data.permitType as PermitType | null,
+          permitType: data.permitType ?? null,
           label: data.label,
           createdAt: data.createdAt,
           updatedAt: data.updatedAt,
@@ -82,9 +82,7 @@ export class PrismaDocumentRepository implements DocumentRepository {
             size: BigInt(version.size),
             checksum: version.checksum,
             notes: version.notes,
-            metadata: (version.metadata ?? undefined) as
-              | Prisma.InputJsonValue
-              | undefined,
+            metadata: version.metadata ?? undefined,
             uploadedBy: version.uploadedBy,
             createdAt: version.createdAt,
           })),
@@ -106,7 +104,7 @@ export class PrismaDocumentRepository implements DocumentRepository {
       where: { id: data.id },
       data: {
         businessProfileId: data.businessProfileId,
-        permitType: data.permitType as PermitType | null,
+        permitType: data.permitType ?? null,
         label: data.label,
         currentVersionId: data.currentVersion?.id ?? null,
         updatedAt: data.updatedAt,
@@ -124,13 +122,13 @@ export class PrismaDocumentRepository implements DocumentRepository {
     });
   }
 
-  private withRelations(): Prisma.DocumentInclude {
+  private withRelations() {
     return {
       currentVersion: true,
       versions: {
         orderBy: { version: 'asc' },
       },
-    };
+    } as const;
   }
 
   private isMissingTableError(error: unknown): boolean {

--- a/backend/src/modules/notifications/infrastructure/mappers/notification.mapper.ts
+++ b/backend/src/modules/notifications/infrastructure/mappers/notification.mapper.ts
@@ -1,22 +1,38 @@
-import { Notification as PrismaNotification } from '@prisma/client';
 import { Notification } from '../../domain/entities/notification.entity';
 import { NotificationEmailStatus } from '../../domain/enums/notification-email-status.enum';
 import { NotificationStatus } from '../../domain/enums/notification-status.enum';
 import { NotificationType } from '../../domain/enums/notification-type.enum';
 
+type PrismaNotificationRecord = {
+  id: string;
+  userId: string;
+  type: NotificationType;
+  title: string;
+  message: string;
+  payload: unknown;
+  status: NotificationStatus;
+  readAt: Date | null;
+  sentAt: Date;
+  emailStatus: NotificationEmailStatus;
+  emailSentAt: Date | null;
+  emailError: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
 export class NotificationMapper {
-  static toDomain(record: PrismaNotification): Notification {
+  static toDomain(record: PrismaNotificationRecord): Notification {
     return Notification.create({
       id: record.id,
       userId: record.userId,
-      type: record.type as NotificationType,
+      type: record.type,
       title: record.title,
       message: record.message,
       payload: (record.payload as Record<string, unknown> | null) ?? null,
-      status: record.status as NotificationStatus,
+      status: record.status,
       readAt: record.readAt,
       sentAt: record.sentAt,
-      emailStatus: record.emailStatus as NotificationEmailStatus,
+      emailStatus: record.emailStatus,
       emailSentAt: record.emailSentAt,
       emailError: record.emailError,
       createdAt: record.createdAt,

--- a/backend/src/modules/notifications/infrastructure/repositories/prisma-notification.repository.ts
+++ b/backend/src/modules/notifications/infrastructure/repositories/prisma-notification.repository.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { NotificationStatus, Prisma } from '@prisma/client';
 import { PrismaService } from '../../../../database/prisma.service';
 import { Notification } from '../../domain/entities/notification.entity';
 import { NotificationEmailStatus } from '../../domain/enums/notification-email-status.enum';
@@ -71,7 +70,7 @@ export class PrismaNotificationRepository implements NotificationRepository {
     const records = await this.prisma.notification.findMany({
       where: {
         userId,
-        status: options.status as NotificationStatus | undefined,
+        status: options.status,
       },
       orderBy: { createdAt: 'desc' },
       skip: options.skip,
@@ -82,9 +81,9 @@ export class PrismaNotificationRepository implements NotificationRepository {
 
   async markAllAsRead(userId: string): Promise<number> {
     const result = await this.prisma.notification.updateMany({
-      where: { userId, status: NotificationStatus.UNREAD },
+      where: { userId, status: DomainNotificationStatus.UNREAD },
       data: {
-        status: NotificationStatus.READ,
+        status: DomainNotificationStatus.READ,
         readAt: new Date(),
         updatedAt: new Date(),
       },
@@ -100,13 +99,10 @@ export class PrismaNotificationRepository implements NotificationRepository {
 
   private toJsonValue(
     payload: Record<string, unknown> | null | undefined,
-  ): Prisma.InputJsonValue | Prisma.NullTypes.JsonNull | undefined {
-    if (payload === null) {
-      return Prisma.JsonNull;
-    }
+  ): Record<string, unknown> | null | undefined {
     if (payload === undefined) {
       return undefined;
     }
-    return payload as Prisma.InputJsonValue;
+    return payload ?? null;
   }
 }


### PR DESCRIPTION
## Summary
- replace direct Prisma model imports with local record interfaces across repositories and mappers so compilation no longer depends on generated client types
- normalize JSON payload handling and enum usage for documents, notifications, and subscriptions to rely on domain definitions
- harden error logging in assistant and Midtrans services by adding guards for generic HTTP-like errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcc64f88c08326a40f8201ac3da643