### PR TITLE
Fix Prisma JSON mappings for nullable metadata fields

### DIFF
--- a/backend/src/modules/business-profile/infrastructure/repositories/prisma-business-permit-profile.repository.ts
+++ b/backend/src/modules/business-profile/infrastructure/repositories/prisma-business-permit-profile.repository.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../../../database/prisma.service';
 import {
   BusinessPermitProfile,
@@ -12,8 +13,6 @@ type PrismaBusinessPermitProfileRecord = NonNullable<
     ReturnType<PrismaService['businessPermitProfile']['findUnique']>
   >
 >;
-
-type PrismaJsonInput = JsonValue | null | undefined;
 
 @Injectable()
 export class PrismaBusinessPermitProfileRepository
@@ -89,16 +88,16 @@ export class PrismaBusinessPermitProfileRepository
 
   private toJsonInput(
     value: JsonValue | null | undefined,
-  ): PrismaJsonInput {
+  ): Prisma.InputJsonValue | Prisma.NullTypes.JsonNull | undefined {
     if (value === undefined) {
-      return undefined as PrismaJsonInput;
+      return undefined;
     }
 
     if (value === null) {
-      return null as PrismaJsonInput;
+      return Prisma.JsonNull;
     }
 
-    return value as unknown as PrismaJsonInput;
+    return value as unknown as Prisma.InputJsonValue;
   }
 
   private fromJsonValue(value: unknown): JsonValue | null {

--- a/backend/src/modules/documents/infrastructure/repositories/prisma-document-version.repository.ts
+++ b/backend/src/modules/documents/infrastructure/repositories/prisma-document-version.repository.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../../../database/prisma.service';
 import { DocumentVersion } from '../../domain/entities/document-version.entity';
 import { DocumentVersionRepository } from '../../domain/repositories/document-version.repository';
@@ -46,7 +47,7 @@ export class PrismaDocumentVersionRepository
         size: BigInt(data.size),
         checksum: data.checksum,
         notes: data.notes,
-        metadata: data.metadata ?? undefined,
+        metadata: this.toJsonInput(data.metadata),
         uploadedBy: data.uploadedBy,
         createdAt: data.createdAt,
       },
@@ -55,5 +56,19 @@ export class PrismaDocumentVersionRepository
 
   async delete(version: DocumentVersion): Promise<void> {
     await this.prisma.documentVersion.delete({ where: { id: version.id } });
+  }
+
+  private toJsonInput(
+    value: Record<string, unknown> | null | undefined,
+  ): Prisma.InputJsonValue | Prisma.NullTypes.JsonNull | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (value === null) {
+      return Prisma.JsonNull;
+    }
+
+    return value as Prisma.InputJsonValue;
   }
 }

--- a/backend/src/modules/documents/infrastructure/repositories/prisma-document.repository.ts
+++ b/backend/src/modules/documents/infrastructure/repositories/prisma-document.repository.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { PrismaService } from '../../../../database/prisma.service';
 import { Document } from '../../domain/entities/document.entity';
@@ -138,15 +139,15 @@ export class PrismaDocumentRepository implements DocumentRepository {
 
   private toJsonInput(
     value: Record<string, unknown> | null | undefined,
-  ) {
+  ): Prisma.InputJsonValue | Prisma.NullTypes.JsonNull | undefined {
     if (value === undefined) {
       return undefined;
     }
 
     if (value === null) {
-      return null;
+      return Prisma.JsonNull;
     }
 
-    return value;
+    return value as Prisma.InputJsonValue;
   }
 }

--- a/backend/src/modules/notifications/infrastructure/repositories/prisma-notification.repository.ts
+++ b/backend/src/modules/notifications/infrastructure/repositories/prisma-notification.repository.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../../../database/prisma.service';
 import { Notification } from '../../domain/entities/notification.entity';
 import { NotificationEmailStatus } from '../../domain/enums/notification-email-status.enum';
@@ -104,16 +105,16 @@ export class PrismaNotificationRepository implements NotificationRepository {
 
   private toJsonValue(
     payload: Record<string, unknown> | null | undefined,
-  ) {
+  ): Prisma.InputJsonValue | Prisma.NullTypes.JsonNull | undefined {
     if (payload === undefined) {
       return undefined;
     }
 
     if (payload === null) {
-      return null;
+      return Prisma.JsonNull;
     }
 
-    return payload;
+    return payload as Prisma.InputJsonValue;
   }
 
   private toPrismaNotificationStatus(


### PR DESCRIPTION
## Summary
- use Prisma-provided JSON helper types when persisting business permit profile data
- normalize document and notification repository JSON conversions to return Prisma.JsonNull for null payloads

## Testing
- npm run build *(fails: nest: not found in PATH in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd90ac5308326bf6478de68c77958